### PR TITLE
modified modelMapper

### DIFF
--- a/src/main/java/com/swacademy/mapcommunity/data/mapper/CommentMapper.java
+++ b/src/main/java/com/swacademy/mapcommunity/data/mapper/CommentMapper.java
@@ -29,10 +29,10 @@ public class CommentMapper {
      */
     public CommentDataEntity toDataEntity(Comment comment) {
         CommentDataEntity commentDataEntity = modelMapper.map(comment, CommentDataEntity.class);
-        Location location = comment.getPost().getPosition();
-        if (location != null) {  //Since the type is different, it must be specified separately.
+        Location position = comment.getPost().getPosition();
+        if (position != null) {  //Since the type is different, it must be specified separately.
             PostDataEntity postDataEntity = commentDataEntity.getPost();
-            postDataEntity.setPosition(new GeometryFactory().createPoint(new Coordinate(location.longitude(), location.latitude())));
+            postDataEntity.setPosition(new GeometryFactory().createPoint(new Coordinate(position.longitude(), position.latitude())));
             commentDataEntity.setPost(postDataEntity);
         }
         return commentDataEntity;

--- a/src/main/java/com/swacademy/mapcommunity/data/mapper/PostMapper.java
+++ b/src/main/java/com/swacademy/mapcommunity/data/mapper/PostMapper.java
@@ -28,9 +28,9 @@ public class PostMapper {
     public PostDataEntity toDataEntity(Post post) {
         PostDataEntity postDataEntity = modelMapper.map(post, PostDataEntity.class);
 
-        Location location = post.getPosition();
-        if (location != null) {
-            postDataEntity.setPosition(new GeometryFactory().createPoint(new Coordinate(location.longitude(), location.latitude())));
+        Location position = post.getPosition();
+        if (position != null) {
+            postDataEntity.setPosition(new GeometryFactory().createPoint(new Coordinate(position.longitude(), position.latitude())));
         }
         return postDataEntity;
     }

--- a/src/main/java/com/swacademy/mapcommunity/domain/entity/Location.java
+++ b/src/main/java/com/swacademy/mapcommunity/domain/entity/Location.java
@@ -1,9 +1,5 @@
 package com.swacademy.mapcommunity.domain.entity;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
-
 /**
  * Value object that express coordinate.
  * @param latitude -90.0 <= latitude <= 90.0
@@ -23,10 +19,6 @@ public record Location(
                 "Latitude value should be in range %s to %s.".formatted(MIN_LATITUDE, MAX_LATITUDE));
         if (longitude <= MIN_LONGITUDE || longitude >= MAX_LONGITUDE) throw new IllegalArgumentException(
                 "Longitude value should be in range %s to %s.".formatted(MIN_LONGITUDE, MAX_LONGITUDE));
-    }
-
-    public Point asPoint() {
-        return new GeometryFactory().createPoint(new Coordinate(longitude, latitude));
     }
 
 }

--- a/src/test/java/com/swacademy/mapcommunity/data/mapper/CommentMapperTest.java
+++ b/src/test/java/com/swacademy/mapcommunity/data/mapper/CommentMapperTest.java
@@ -8,6 +8,8 @@ import com.swacademy.mapcommunity.domain.entity.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -101,7 +103,7 @@ class CommentMapperTest {
         postDataEntity1.setId(10L);
         postDataEntity1.setTitle("test title");
         postDataEntity1.setContent("this tis content");
-        postDataEntity1.setPosition(new Location(37.123456, 127.123456).asPoint());
+        postDataEntity1.setPosition(new GeometryFactory().createPoint(new Coordinate(127.123456, 37.123456)));
         postDataEntity1.setPostLike(0);
         postDataEntity1.setCreatedAt(LocalDateTime.now());
         postDataEntity1.setUpdatedAt(LocalDateTime.now());

--- a/src/test/java/com/swacademy/mapcommunity/data/mapper/PostMapperTest.java
+++ b/src/test/java/com/swacademy/mapcommunity/data/mapper/PostMapperTest.java
@@ -10,6 +10,8 @@ import com.swacademy.mapcommunity.domain.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.modelmapper.ModelMapper;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -78,7 +80,7 @@ class PostMapperTest {
         postDataEntity.setTitle("Test Title");
         postDataEntity.setContent("Test Content");
         postDataEntity.setPostLike(0);
-        postDataEntity.setPosition(new Location(37.123456, 127.123456).asPoint());
+        postDataEntity.setPosition(new GeometryFactory().createPoint(new Coordinate(127.123456, 37.123456)));
 
         //Create a UserDataEntity object to convert use FK
         UserDataEntity userDataEntity = new UserDataEntity();

--- a/src/test/java/com/swacademy/mapcommunity/data/mapper/UserMapperTest.java
+++ b/src/test/java/com/swacademy/mapcommunity/data/mapper/UserMapperTest.java
@@ -13,7 +13,10 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -28,8 +31,12 @@ import static org.junit.jupiter.api.Assertions.*;
 @ActiveProfiles("local")
 class UserMapperTest {
 
-    private final ModelMapper modelMapper = new ModelMapper();
-    private final UserMapper userMapper = new UserMapper(modelMapper);
+    private final UserMapper userMapper;
+
+    public UserMapperTest(@Autowired PostMapper postMapper, @Autowired CommentMapper commentMapper) {
+        ModelMapper modelMapper = new ModelMapper();
+        this.userMapper = new UserMapper(modelMapper, postMapper, commentMapper);
+    }
 
     @Test
     @DisplayName("Object toDataEntity mapper test with User, Post")
@@ -105,7 +112,7 @@ class UserMapperTest {
         postDataEntity1.setContent("post content 1");
         postDataEntity1.setCreatedAt(LocalDateTime.now());
         postDataEntity1.setUpdatedAt(LocalDateTime.now());
-        postDataEntity1.setPosition(new Location(36.369934530965246, 127.34573990100932).asPoint());
+        postDataEntity1.setPosition(new GeometryFactory().createPoint(new Coordinate(128.34573990100932, 36.369934530965246)));
 
         PostDataEntity postDataEntity2 = new PostDataEntity();
         postDataEntity2.setId(2L);
@@ -113,7 +120,7 @@ class UserMapperTest {
         postDataEntity2.setContent("test tests");
         postDataEntity2.setCreatedAt(LocalDateTime.now());
         postDataEntity2.setUpdatedAt(LocalDateTime.now());
-        postDataEntity2.setPosition(new Location(36.369934530965246, 127.34573990100932).asPoint());
+        postDataEntity2.setPosition(new GeometryFactory().createPoint(new Coordinate(127.34573990100932, 36.369934530965246)));
 
         postDataEntity1.setUser(userDataEntity);
         postDataEntity2.setUser(userDataEntity);
@@ -155,7 +162,7 @@ class UserMapperTest {
         postDataEntity1.setContent("post content 1");
         postDataEntity1.setCreatedAt(LocalDateTime.now());
         postDataEntity1.setUpdatedAt(LocalDateTime.now());
-        postDataEntity1.setPosition(new Location(36.369934530965246, 127.34573990100932).asPoint());
+        postDataEntity1.setPosition(new GeometryFactory().createPoint(new Coordinate(127.34573990100932, 36.369934530965246)));
 
         PostDataEntity postDataEntity2 = new PostDataEntity();
         postDataEntity2.setId(2L);
@@ -163,7 +170,7 @@ class UserMapperTest {
         postDataEntity2.setContent("test tests");
         postDataEntity2.setCreatedAt(LocalDateTime.now());
         postDataEntity2.setUpdatedAt(LocalDateTime.now());
-        postDataEntity2.setPosition(new Location(36.369934530965246, 127.34573990100932).asPoint());
+        postDataEntity2.setPosition(new GeometryFactory().createPoint(new Coordinate(127.34573990100932, 36.369934530965246)));
 
         postDataEntity1.setUser(userDataEntity);
         postDataEntity2.setUser(userDataEntity);
@@ -193,7 +200,6 @@ class UserMapperTest {
         assertEquals(user.getCreatedAt(), userDataEntity.getCreatedAt());
         assertEquals(user.getUpdatedAt(), userDataEntity.getUpdatedAt());
         assertEquals(user.getBirth(), userDataEntity.getBirth());
-
     }
 
 }


### PR DESCRIPTION
### UserMapper Class
In DataEntity and Entity, the position field of the Post is different in type(Location, Point).
Therefore, when using ModelMapper, additional types must be defined.   
When defining this additional type, the point converter method was created using Converter.   
   
UserMapperClass converts User and UserDataEntity, where User and UserDataEntity have Post and PostDataEntity objects as fields.
As I said before, the position field of the Post is different, so the Posts are imported and configured here as well.