### PR TITLE
presentation layer-infinite recursion Error fix

### DIFF
--- a/src/main/java/com/swacademy/mapcommunity/data/entity/UserDataEntity.java
+++ b/src/main/java/com/swacademy/mapcommunity/data/entity/UserDataEntity.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Getter @Setter
 public class UserDataEntity extends BaseInformation {
     @Id
-    //@GeneratedValue(strategy = GenerationType.AUTO)  //@Todo UUID의 random 생성 또는 GenerationType을 change
+    @GeneratedValue(strategy = GenerationType.AUTO)  //@Todo Long -> UUID and UUID.random
     @Column(name = "id", nullable = false, insertable = false, updatable = false)
     private Long id;
 

--- a/src/main/java/com/swacademy/mapcommunity/data/mapper/PostMapper.java
+++ b/src/main/java/com/swacademy/mapcommunity/data/mapper/PostMapper.java
@@ -1,8 +1,6 @@
 package com.swacademy.mapcommunity.data.mapper;
 
-import com.swacademy.mapcommunity.data.entity.CommentDataEntity;
 import com.swacademy.mapcommunity.data.entity.PostDataEntity;
-import com.swacademy.mapcommunity.domain.entity.Comment;
 import com.swacademy.mapcommunity.domain.entity.Location;
 import com.swacademy.mapcommunity.domain.entity.Post;
 import org.locationtech.jts.geom.Coordinate;
@@ -39,12 +37,12 @@ public class PostMapper {
         if (position != null) {
             postDataEntity.setPosition(new GeometryFactory().createPoint(new Coordinate(position.longitude(), position.latitude())));
         }
-        List<CommentDataEntity> commentDataEntities = new ArrayList<>();
-        for (Comment comment : post.getComments()) {
-            CommentDataEntity commentDataEntity = commentMapper.toDataEntity(comment);
-            commentDataEntities.add(commentDataEntity);
-        }
-        postDataEntity.setComments(commentDataEntities);
+//        List<CommentDataEntity> commentDataEntities = new ArrayList<>();
+//        for (Comment comment : post.getComments()) {
+//            CommentDataEntity commentDataEntity = commentMapper.toDataEntity(comment);
+//            commentDataEntities.add(commentDataEntity);
+//        }
+//        postDataEntity.setComments(commentDataEntities);
 
         return postDataEntity;
     }
@@ -62,12 +60,12 @@ public class PostMapper {
             post.setPosition(new Location(point.getY(), point.getX()));
         }
 
-        List<Comment> comments = new ArrayList<>();
-        for (CommentDataEntity commentDataEntity : postDataEntity.getComments()) {
-            Comment comment = commentMapper.toEntity(commentDataEntity);
-            comments.add(comment);
-        }
-        post.setComments(comments);
+//        List<Comment> comments = new ArrayList<>();
+//        for (CommentDataEntity commentDataEntity : postDataEntity.getComments()) {
+//            Comment comment = commentMapper.toEntity(commentDataEntity);
+//            comments.add(comment);
+//        }
+//        post.setComments(comments);
 
         return post;
     }

--- a/src/main/java/com/swacademy/mapcommunity/data/mapper/UserMapper.java
+++ b/src/main/java/com/swacademy/mapcommunity/data/mapper/UserMapper.java
@@ -36,8 +36,8 @@ public class UserMapper {
         this.postMapper = postMapper;
         this.commentMapper = commentMapper;
 
-        modelMapper.createTypeMap(Post.class, PostDataEntity.class)
-                .addMappings(mapper -> mapper.using(pointConverter()).map(Post::getPosition, PostDataEntity::setPosition));
+//        modelMapper.createTypeMap(Post.class, PostDataEntity.class)
+//                .addMappings(mapper -> mapper.using(pointConverter()).map(Post::getPosition, PostDataEntity::setPosition));
         this.modelMapper.createTypeMap(Location.class, Point.class);
    }
 

--- a/src/main/java/com/swacademy/mapcommunity/domain/service/UserService.java
+++ b/src/main/java/com/swacademy/mapcommunity/domain/service/UserService.java
@@ -67,6 +67,6 @@ public class UserService {
 //        }
 
         //put in temporarily //to be converted to security
-        return getUserById(20200411L);
+        return getUserById(1L);
     }
 }

--- a/src/main/java/com/swacademy/mapcommunity/presentation/dto/UserDto.java
+++ b/src/main/java/com/swacademy/mapcommunity/presentation/dto/UserDto.java
@@ -18,6 +18,7 @@ public class UserDto {
     private String nickname;
     private Gender gender;
     private LocalDate birth;
+    @JsonIgnore
     private List<PostDto> posts = new ArrayList<>();
     @JsonIgnore
     private List<CommentDto> comments = new ArrayList<>();


### PR DESCRIPTION
### ⚠️  presentation layer JSON Serialize -> infinite recursion Error 발생   
User class가 List 타입의 필드로 Posts, Comments 들을 가지고  이 Posts, Comments 필드들이 다시 User를 가지는 부분에서 무한 참조 에러 발생       
Controller에서 Dto 반환 시 Dto가 앞서 말한 무한 참조 가능성을 가진 List 필드를 가지고 있는데 List 필드(posts, comments)를 직렬화하지 않도록 `@JsonIgnore` 어노테이션 사용

### ⚠️ Post 작성 시 2개 이상 insert 시 "location is null" Error 발생
data layer의 Mapper 문제 - UserMapper Constructor에서 아래와 같은 코드 주석 처리     
```
modelMapper.createTypeMap(Post.class, PostDataEntity.class).addMappings(mapper -> mapper.using(pointConverter()).map(Post::getPosition, PostDataEntity::setPosition));
```

**❗ 추후 data layer - Mapper 수정 필요**